### PR TITLE
Make push work

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,27 +41,28 @@ Push a log file:
 
         datalake push --start 2015-03-20T00:05.345Z
             --end 2015-03-20T23:59.114Z \
-            --where webserver01 --what nginx /path/to/nginx.log \
-            --data-version 0
+            --data-version 0 --who webteam \
+            --where webserver01 --what nginx /path/to/nginx.log
 
 Push a log file, specifying some extra detail:
 
         datalake push --start 2015-03-20T00:00:05.345Z \
             --end 2015-03-20T23:59:59.114Z \
-            --what syslog --where webserver01 --data-version 0 \
+            --data-version 0 --who webteam \
+            --what syslog --where webserver01 \
             --tags app=MemeGenerator,magic=123 /path/to/my.log
 
 List the syslog and foobar files available from webserver01 since the specified
 start date.
 
         datalake list --where webserver01 --start 2015-03-20 --end `date -u` \
-            --what syslog,foobar
+            --what syslog,foobar --who webteam
 
 Fetch the nginx log files from webserver01 and webserver02 to the current
 directory:
 
         datalake fetch --where webserver01,webserver02 --start 2015-03-20 \
-            --end `date -u` --what nginx
+            --end `date -u` --what nginx --who webteam
 
 Metadata
 ========
@@ -75,6 +76,7 @@ with each file. In JSON, the metadata looks something like this:
             "end": "2015-03-20T23:59:59.114Z",
             "where": "webserver02",
             "what": "syslog",
+            "who": "webteam",
             "data-version": "0",
             "tags": {
                 "app": "MemeGenerator",
@@ -94,6 +96,9 @@ file represents a snapshot of something like a weekly report.
 where: This is the location or server that generated the file. It is required.
 
 what: This is the process or program that generated the file. It is required.
+
+who: This is the organizational unit (e.g., team, project) responsible for the
+generation of the data. It is required.
 
 data-version: This is the data version. The format of the version is up to the
 user. If the format of the contents of the file changes, this version should

--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ Developer Setup
 
         mkvirtualenv datalake # Or however you like to manage virtualenvs
         pip install -r requirements.txt -r test-requirements.txt
-        nosetests
+        py.test

--- a/datalake/dlfile.py
+++ b/datalake/dlfile.py
@@ -1,6 +1,7 @@
 from metadata import Metadata
 import os
-
+from memoized_property import memoized_property
+from pyblake2 import blake2b
 
 class File(object):
     '''A File to be manipulated by the Archive
@@ -13,9 +14,28 @@ class File(object):
             metadata = Metadata(metadata)
         self.metadata = metadata
         self._fd = open(path, 'r')
+        self._path = path
         self.name = os.path.basename(path)
         self._initialize_methods_from_fd()
 
     def _initialize_methods_from_fd(self):
         for m in ['read', 'readlines', 'seek', 'tell', 'close']:
             setattr(self, m, getattr(self._fd, m))
+
+    _HASH_BUF_SIZE = 65536
+
+    def _calculate_hash(self):
+        # this takes just under 2s on my laptop for a 1GB file.
+        b2 = blake2b()
+        with open(self._path, 'rb') as f:
+            while True:
+                data = f.read(self._HASH_BUF_SIZE)
+                if not data:
+                    break
+                b2.update(data)
+        return b2.hexdigest()
+
+    @memoized_property
+    def id(self):
+        '''a unique id for this file'''
+        return self._calculate_hash()

--- a/datalake/dlfile.py
+++ b/datalake/dlfile.py
@@ -15,7 +15,7 @@ class File(object):
         self.metadata = metadata
         self._fd = open(path, 'r')
         self._path = path
-        self.name = os.path.basename(path)
+        self._basename = os.path.basename(path)
         self._initialize_methods_from_fd()
 
     def _initialize_methods_from_fd(self):

--- a/datalake/metadata.py
+++ b/datalake/metadata.py
@@ -30,13 +30,13 @@ class Metadata(dict):
     def _validate_required_fields(self):
         for f in self._REQUIRED_METADATA_FIELDS:
             if f not in self:
-                msg = '%s is a require field'.format(f)
+                msg = '"{}" is a require field'.format(f)
                 raise InvalidDatalakeMetadata(msg)
 
     def _validate_version(self):
         v = self['version']
         if v != '0':
-            msg = 'Found version %s. Only "0" is supported'.format(v)
+            msg = 'Found version {}. Only "0" is supported'.format(v)
             raise UnsupportedDatalakeMetadataVersion(msg)
 
     def _normalize_dates(self):
@@ -49,5 +49,5 @@ class Metadata(dict):
         try:
             return dateparse(date)
         except ValueError:
-            msg = 'could not parse a date from %s'.format(date)
+            msg = 'could not parse a date from {}'.format(date)
             raise InvalidDatalakeMetadata(msg)

--- a/datalake/metadata.py
+++ b/datalake/metadata.py
@@ -43,6 +43,8 @@ class Metadata(dict):
     def _normalize_dates(self):
         for d in ['start', 'end']:
             date = self._normalize_date(self[d])
+            # keep the datetimes around for internal convenience
+            setattr(self, '_' + d, date)
             self[d] = date.isoformat() + 'Z'
 
     @staticmethod

--- a/datalake/metadata.py
+++ b/datalake/metadata.py
@@ -25,7 +25,8 @@ class Metadata(dict):
         self._validate_required_fields()
         self._validate_version()
 
-    _REQUIRED_METADATA_FIELDS = ['version', 'start', 'end', 'where', 'what']
+    _REQUIRED_METADATA_FIELDS = ['version', 'start', 'end', 'where', 'what',
+                                 'who']
 
     def _validate_required_fields(self):
         for f in self._REQUIRED_METADATA_FIELDS:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ConfigArgParse>=0.9.3
 boto>=2.38.0
 memoized_property>=1.0.2
 simplejson>=3.7
+pyblake2>=0.9.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
-nose==1.3.6
 moto==0.4.2
 twine==1.5.0
 pip==7.1.0
 wheel==0.24.0
+pytest==2.7.2

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -20,6 +20,7 @@ class TestArchiveS3Tests(TestCase):
             'end': '2015-03-20T23:59:59.999Z',
             'where': 'nebraska',
             'what': 'apache',
+            'who': 'yourmom',
         }
         self.bucket_name = 'datalake-test'
         self.bucket_url = 's3://' + self.bucket_name + '/'

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -1,0 +1,42 @@
+import pytest
+import random
+import string
+from datetime import datetime, timedelta
+
+from datalake import File
+
+def random_word(length):
+    return ''.join(random.choice(string.lowercase) for i in range(length))
+
+def random_interval():
+    now = datetime.now()
+    start = now - timedelta(days=random.randint(0, 365*3))
+    end = start - timedelta(days=random.randint(1, 10))
+    return start.isoformat(), end.isoformat()
+
+def random_metadata():
+    start, end = random_interval()
+    return {
+        'version': '0',
+        'start': start,
+        'end': end,
+        'where': random_word(10),
+        'what': random_word(10),
+    }
+
+def random_file(tmpdir):
+    name = random_word(10)
+    content = random_word(256)
+    f = tmpdir.join(name)
+    f.write(content)
+    return File(f.strpath, random_metadata())
+
+@pytest.fixture
+def random_files(tmpdir):
+    def get_randfiles(n):
+        return [random_file(tmpdir) for _ in range(n)]
+    return get_randfiles
+
+def test_file_id_probably_unique(random_files):
+    files = random_files(2)
+    assert files[0].id != files[1].id

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -22,6 +22,7 @@ def random_metadata():
         'end': end,
         'where': random_word(10),
         'what': random_word(10),
+        'who': random_word(10),
     }
 
 def random_file(tmpdir):

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -13,6 +13,7 @@ class TestMetadataValidation(TestCase):
             'end': '2015-03-20T23:59:59.999Z',
             'where': 'nebraska',
             'what': 'apache',
+            'who': 'me',
         }
 
     def test_missing_version(self):


### PR DESCRIPTION
Hoping that @moore will take a look at this one. A couple of thoughts/questions:

1. Two files with the same name and origin that were generated on the same day will collide in the url scheme even if they represent different timeframes. I considered addressing this by adding some of the metadata fields to the id hashing. But then we can't checksum the file independent of the metadata. I guess I could distinguish between what I call the "id" and the "checksum." Thoughts?

2. The default 64-byte digest feel kind of obnoxious. Any objection if I chop it down to 20?
