### PR TITLE
add skeletal queuing capability

### DIFF
--- a/datalake/__init__.py
+++ b/datalake/__init__.py
@@ -1,7 +1,8 @@
 import pyver
 
 __version__, __version_info__ = pyver.get_version(pkg='datalake')
-__all__ = ['File', 'Archive']
+__all__ = ['File', 'Archive', 'Uploader', 'Enqueuer']
 
 from dlfile import File
 from archive import Archive
+from queue import Uploader, Enqueuer

--- a/datalake/archive.py
+++ b/datalake/archive.py
@@ -57,12 +57,15 @@ class Archive(object):
         returns the url to which the file was pushed.
         '''
         self._upload_file(f)
-        return self._get_s3_url(f)
+        return self.url_from_file(f)
 
     def _upload_file(self, f):
         key = self._s3_key_from_metadata(f)
         key.set_metadata('datalake', json.dumps(f.metadata))
         key.set_contents_from_string(f.read())
+
+    def url_from_file(self, f):
+        return self._get_s3_url(f)
 
     _URL_FORMAT = 's3://{bucket}/{key}'
 
@@ -79,17 +82,15 @@ class Archive(object):
     def _s3_bucket(self):
         return self._s3_conn.get_bucket(self._s3_bucket_name)
 
-    _KEY_FORMAT = '{prefix}-{where}/{what}/{start}/{id}-{name}'
+    _KEY_FORMAT = '{prefix}-{where}/{what}/{start}/{id}'
 
     def _s3_key_from_metadata(self, f):
         # For performance reasons, s3 keys should start with a short random
         # sequence:
         # https://aws.amazon.com/blogs/aws/amazon-s3-performance-tips-tricks-seattle-hiring-event/
         # http://docs.aws.amazon.com/AmazonS3/latest/dev/request-rate-perf-considerations.html
-        name = f._basename
         prefix = f.metadata['hash'][0]
-        key_name = self._KEY_FORMAT.format(name=name,
-                                           prefix=prefix,
+        key_name = self._KEY_FORMAT.format(prefix=prefix,
                                            **f.metadata)
         return Key(self._s3_bucket, name=key_name)
 

--- a/datalake/dlfile.py
+++ b/datalake/dlfile.py
@@ -2,16 +2,32 @@ import os
 from memoized_property import memoized_property
 from pyblake2 import blake2b
 
+from datalake_common import Metadata
+
 
 class File(object):
     '''A File to be manipulated by the Archive'''
 
-    def __init__(self, path):
+    def __init__(self, path, **metadata_fields):
+        '''Create a File
+
+        Args:
+
+            path: path to the file
+
+            metadata_fields: known metadata fields that go with this
+            file. Missing fields will be added if they can be
+            determined. Othwerise, InvalidDatalakeMetadata will be raised.
+
+        '''
         self._fd = open(path, 'r')
         self._path = os.path.abspath(path)
         self._basename = os.path.basename(path)
         self._initialize_methods_from_fd()
-        self.metadata = None
+        if 'hash' not in metadata_fields:
+            # do not recalculate the hash if it is already known
+            metadata_fields['hash'] = self._calculate_hash()
+        self.metadata = Metadata(metadata_fields)
 
     def _initialize_methods_from_fd(self):
         for m in ['read', 'readlines', 'seek', 'tell', 'close']:
@@ -20,6 +36,7 @@ class File(object):
     _HASH_BUF_SIZE = 65536
 
     def _calculate_hash(self):
+        '''16-byte blake2b hash over the content of this file'''
         # this takes just under 2s on my laptop for a 1GB file.
         b2 = blake2b(digest_size=16)
         with open(self._path, 'rb') as f:
@@ -29,8 +46,3 @@ class File(object):
                     break
                 b2.update(data)
         return b2.hexdigest()
-
-    @memoized_property
-    def hash(self):
-        '''16-byte blake2b hash over the content of this file'''
-        return self._calculate_hash()

--- a/datalake/dlfile.py
+++ b/datalake/dlfile.py
@@ -22,7 +22,6 @@ class File(object):
         '''
         self._fd = open(path, 'r')
         self._path = os.path.abspath(path)
-        self._basename = os.path.basename(path)
         self._initialize_methods_from_fd()
         if 'hash' not in metadata_fields:
             # do not recalculate the hash if it is already known

--- a/datalake/queue.py
+++ b/datalake/queue.py
@@ -1,0 +1,125 @@
+'''manage a queue of datalake files
+
+This allows users to enqueue files to be uploaded to the datalake. An uploader
+process runs that actually does the uploader work.
+
+Under the hood, the queue is a directory which the Uploader watches. The
+Enqueuer enqueues files by setting an extended filesystem attribute with the
+fully-formed metadata for the file to be uploaded, and symlinking it to the
+queue directory. This ensures that the enqueuer fails in the user's face
+instead of silently behind the user's back. The uploader uses inotify to
+monitor the queue directory. When a file arrives, it gets uploaded and the
+symlink deleted.
+
+'''
+from os import environ
+from datalake_common.errors import InsufficientConfiguration
+from xattr import setxattr, getxattr
+import pyinotify
+from logging import getLogger
+import os
+import time
+import shutil
+
+from datalake_common import Metadata
+from datalake import File
+
+
+log = getLogger('datalake-queue')
+
+
+DATALAKE_METADATA_XATTR = 'user.datalake-metadata'
+
+
+class DatalakeQueueBase(object):
+
+    def __init__(self, queue_dir=None):        
+        self.queue_dir = queue_dir or environ.get('DATALAKE_QUEUE_DIR')
+        self._validate_queue_dir()
+
+    def _validate_queue_dir(self):
+        if self.queue_dir is None:
+            raise InsufficientConfiguration('Please specify a queue directory')
+        self.queue_dir = os.path.abspath(self.queue_dir)
+
+
+class Enqueuer(DatalakeQueueBase):
+
+    def enqueue(self, path, **metadata_fields):
+        '''enqueue a file with the specified metadata o be pushed
+
+        Returns the File with complete metadata that will be pushed.
+        '''
+        log.info('Enqueing ' + path)
+        f = File(path, **metadata_fields)
+        setxattr(path, DATALAKE_METADATA_XATTR, f.metadata.json)
+        dest = os.path.join(self.queue_dir, f.metadata['id'])
+        os.symlink(path, dest)        
+        return f
+
+
+class Uploader(DatalakeQueueBase):
+
+    def __init__(self, archive, queue_dir):
+        super(Uploader, self).__init__(queue_dir)
+        self._archive = archive
+
+    class EventHandler(pyinotify.ProcessEvent):
+
+        def __init__(self, callback):
+            super(Uploader.EventHandler, self).__init__()
+            self.callback = callback
+
+        def process_IN_CREATE(self, event):
+            self.callback(event.pathname)
+
+    def _setup_watch_manager(self, timeout):
+        if timeout is not None:
+            timeout = int(timeout * 1000)
+        self._wm = pyinotify.WatchManager()
+        self._handler = Uploader.EventHandler(self._push)
+        self._notifier = pyinotify.Notifier(self._wm, self._handler,
+                                            timeout=timeout)
+        self._wm.add_watch(self.queue_dir, pyinotify.IN_CREATE)
+
+    def _push(self, path):
+        metadata = Metadata.from_json(getxattr(path, DATALAKE_METADATA_XATTR))
+        f = File(path, **metadata)
+        url = self._archive.push(f)
+        log.info('Pushed ' +  path + ' to ' + url)
+        os.unlink(path)
+
+    def listen(self, timeout=None):
+        '''listen for files in the queue directory and push them'''
+        for f in os.listdir(self.queue_dir):
+            path = os.path.join(self.queue_dir, f)
+            self._push(path)
+
+        self._run(timeout)
+
+    INFINITY = None
+
+    def _run(self, timeout):
+
+        self._prepare_to_track_run_time(timeout)
+        self._notifier.process_events()
+        while self._notifier.check_events():
+            self._notifier.read_events()
+            self._notifier.process_events()
+            if self._update_time_remaining() == 0:
+                break
+
+    def _update_time_remaining(self):
+        if self._run_time_remaining is self.INFINITY:
+            return self.INFINITY
+        now = time.time()
+        duration = now - self._run_start
+        self._run_time_remaining -= duration
+        self._run_time_remaining = max(self._run_time_remaining, 0)
+        self._run_start = now
+        return self._run_time_remaining
+
+    def _prepare_to_track_run_time(self, timeout):
+        self._setup_watch_manager(timeout)
+        self._run_start = time.time()
+        self._run_time_remaining = timeout

--- a/datalake/scripts/cli.py
+++ b/datalake/scripts/cli.py
@@ -104,5 +104,5 @@ def push(**kwargs):
 @clean_up_datalake_errors
 def _push(**kwargs):
     filename = kwargs.pop('file')
-    url = archive.push(filename, **kwargs)
+    url = archive.prepare_metadata_and_push(filename, **kwargs)
     click.echo('Pushed {} to {}'.format(filename, url))

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(name='datalake',
           'click>=4.1',
           'datalake-common>=0.4',
           'python-dotenv>=0.1.3',
+          'pyinotify>=0.9.4',
+          'xattr>=0.7.8',
       ],
       extras_require={
           'test': [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,9 @@ import string
 from datetime import datetime, timedelta
 from moto import mock_s3
 import boto
+from urlparse import urlparse
+
+from datalake import File, Archive
 
 
 @pytest.fixture
@@ -20,6 +23,26 @@ def s3_conn(request):
 
 BUCKET_NAME = 'datalake-test'
 
+
 @pytest.fixture
 def s3_bucket(s3_conn):
     return s3_conn.create_bucket(BUCKET_NAME)
+
+
+@pytest.fixture
+def archive(s3_bucket):
+    bucket_url = 's3://' + s3_bucket.name + '/'
+    return Archive(bucket_url)
+
+
+@pytest.fixture
+def s3_key(s3_conn):
+
+    def get_s3_key(url):
+        url = urlparse(url)
+        assert url.scheme == 's3'
+        bucket = s3_conn.get_bucket(url.netloc)
+        return bucket.get_key(url.path)
+
+    return get_s3_key
+

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -1,27 +1,8 @@
 import pytest
 from tempfile import NamedTemporaryFile
-from urlparse import urlparse
 import simplejson as json
 from datalake_common.tests import random_metadata, tmpfile
 
-from datalake import File, Archive
-
-
-@pytest.fixture
-def archive(s3_bucket):
-    bucket_url = 's3://' + s3_bucket.name + '/'
-    return Archive(bucket_url)
-
-@pytest.fixture
-def s3_key(s3_conn):
-
-    def get_s3_key(url):
-        url = urlparse(url)
-        assert url.scheme == 's3'
-        bucket = s3_conn.get_bucket(url.netloc)
-        return bucket.get_key(url.path)
-
-    return get_s3_key
 
 def test_push_file(archive, random_metadata, tmpfile, s3_key):
     expected_content = 'mwahaha'

--- a/test/test_archive.py
+++ b/test/test_archive.py
@@ -26,7 +26,7 @@ def s3_key(s3_conn):
 def test_push_file(archive, random_metadata, tmpfile, s3_key):
     expected_content = 'mwahaha'
     f = tmpfile(expected_content)
-    url = archive.push(f, **random_metadata)
+    url = archive.prepare_metadata_and_push(f, **random_metadata)
     from_s3 = s3_key(url)
     assert from_s3.get_contents_as_string() == expected_content
     metadata = from_s3.get_metadata('datalake')

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -1,15 +1,18 @@
 import pytest
-from datalake_common.tests import random_word
+from datalake_common.tests import random_word, random_metadata
+from datalake_common import InvalidDatalakeMetadata
 
 from datalake import File
 
 
-def random_file(tmpdir):
+def random_file(tmpdir, metadata=None):
     name = random_word(10)
     content = random_word(256)
     f = tmpdir.join(name)
     f.write(content)
-    return File(f.strpath)
+    if metadata is None:
+        metadata = random_metadata()
+    return File(f.strpath, **metadata)
 
 @pytest.fixture
 def random_files(tmpdir):
@@ -19,8 +22,17 @@ def random_files(tmpdir):
 
 def test_file_hash_different(random_files):
     files = random_files(2)
-    assert files[0].hash != files[1].hash
+    assert files[0].metadata['hash'] != files[1].metadata['hash']
 
 def test_non_existent_file():
     with pytest.raises(IOError):
         File('surelythisfiledoesnotexist.txt')
+
+def test_not_enough_metadata(tmpdir):
+    with pytest.raises(InvalidDatalakeMetadata):
+        random_file(tmpdir, metadata={'where': 'foo'})
+
+def test_hash_not_overwritten(tmpdir, random_metadata):
+    random_metadata['hash'] = '1234'
+    f = random_file(tmpdir, metadata=random_metadata)
+    assert f.metadata['hash'] == random_metadata['hash']

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -1,0 +1,67 @@
+import pytest
+from datalake_common.tests import random_word, random_metadata, tmpfile
+import json
+from threading import Timer
+import os
+
+from datalake import Archive, Enqueuer, Uploader
+
+
+@pytest.fixture
+def queue_dir(tmpdir):
+    d = os.path.join(str(tmpdir), 'queue')
+    os.mkdir(d)
+    return d
+
+
+@pytest.fixture
+def enqueuer(queue_dir):
+    return Enqueuer(queue_dir)
+
+@pytest.fixture
+def uploader(archive, queue_dir):
+    return Uploader(archive, queue_dir)
+
+
+@pytest.fixture
+def uploaded_file_validator(archive, s3_key):
+
+    def validator(f):
+        expected_content = f.read()
+        url = archive.url_from_file(f)
+        from_s3 = s3_key(url)
+        assert from_s3 is not None
+        assert from_s3.get_contents_as_string() == expected_content
+        metadata = json.loads(from_s3.get_metadata('datalake'))
+        assert metadata == f.metadata
+
+    return validator
+
+
+@pytest.fixture
+def random_file(tmpfile, random_metadata):
+    expected_content = random_word(100)
+    return tmpfile(expected_content)
+
+
+def test_upload_existing(enqueuer, uploader, random_file, random_metadata,
+                         uploaded_file_validator):
+    f = enqueuer.enqueue(random_file, **random_metadata)
+    uploader.listen(timeout=0.1)
+    uploaded_file_validator(f)
+
+
+def test_upload_incoming(enqueuer, uploader, random_file, random_metadata,
+                         uploaded_file_validator):
+
+    enqueued_files = []
+    def enqueue():
+        f = enqueuer.enqueue(random_file, **random_metadata)
+        enqueued_files.append(f)
+
+    t = Timer(0.5, enqueue)
+    t.start()
+    uploader.listen(timeout=1.0)
+
+    for f in enqueued_files:
+        uploaded_file_validator(f)


### PR DESCRIPTION
Use a common directory, symlinks, and inotify to form a skeletal queuing capability. Notable work remains on this (e.g., handling exceptions in listener, error case coverage, CLI, perhaps multithreaded upload). This patch is meant to establish the basic idea.