### PR TITLE
make queuing features optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 python:
 - '2.7'
+env:
+  - EXTRAS='[test]'
+  - EXTRAS='[test,queuable]'
 install:
-- pip install -e .[test]
+  - pip install -e .${EXTRAS}
 before_script:
   - flake8 .
 script:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Installation
 
         pip install datalake
 
+If you plan to use the queuing feature, you must install some extra
+dependencies:
+
+        apt-get install libffi-dev # or equivalent
+        pip install datalake[queuable]
+
 Configuration
 =============
 
@@ -86,8 +92,9 @@ blappo-14321359:
 Developer Setup
 ===============
 
+        apt-get install libffi-dev # to enable queuable feature
         mkvirtualenv datalake # Or however you like to manage virtualenvs
-        pip install -e .[test]
+        pip install -e .[queuable, test]
         flake8 .
         py.test
 

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(name='datalake',
           'click>=4.1',
           'datalake-common>=0.4',
           'python-dotenv>=0.1.3',
-          'pyinotify>=0.9.4',
-          'xattr>=0.7.8',
       ],
       extras_require={
           'test': [
@@ -55,6 +53,12 @@ setup(name='datalake',
               'pip==7.1.0',
               'wheel==0.24.0',
               'flake8==2.5.0',
+          ],
+          # the queuable feature allows users to offload their datalake pushes
+          # to a separate uploader process.
+          'queuable': [
+              'pyinotify>=0.9.4',
+              'xattr>=0.7.8',
           ]
       },
       entry_points="""

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -17,8 +17,10 @@ import json
 from threading import Timer
 import os
 from datalake_common.tests import random_word
+from datalake_common.errors import InsufficientConfiguration
 
 from datalake import Enqueuer, Uploader
+from datalake.queue import has_queue
 
 
 @pytest.fixture
@@ -59,6 +61,7 @@ def random_file(tmpfile, random_metadata):
     return tmpfile(expected_content)
 
 
+@pytest.mark.skipif(not has_queue, reason='requires queuable features')
 def test_upload_existing(enqueuer, uploader, random_file, random_metadata,
                          uploaded_file_validator):
     f = enqueuer.enqueue(random_file, **random_metadata)
@@ -66,6 +69,7 @@ def test_upload_existing(enqueuer, uploader, random_file, random_metadata,
     uploaded_file_validator(f)
 
 
+@pytest.mark.skipif(not has_queue, reason='requires queuable features')
 def test_upload_incoming(enqueuer, uploader, random_file, random_metadata,
                          uploaded_file_validator):
 
@@ -81,3 +85,15 @@ def test_upload_incoming(enqueuer, uploader, random_file, random_metadata,
 
     for f in enqueued_files:
         uploaded_file_validator(f)
+
+
+@pytest.mark.skipif(has_queue, reason='requires queuable to be not installed')
+def test_uploader_queable_not_installed(archive, queue_dir):
+    with pytest.raises(InsufficientConfiguration):
+        Uploader(archive, queue_dir)
+
+
+@pytest.mark.skipif(has_queue, reason='requires queuable to be not installed')
+def test_enqueuer_queable_not_installed(queue_dir):
+    with pytest.raises(InsufficientConfiguration):
+        Enqueuer(queue_dir)


### PR DESCRIPTION
The queuing features are meant for servers. Some people will just want to use the client and will not want to go resolving the dependencies required for this feature.