### PR TITLE
Update to latest metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,13 @@ Push a log file:
 
         datalake push --start 2015-03-20T00:05:32.345Z
             --end 2015-03-20T23:59.114Z \
-            --where webserver01 --what nginx /path/to/nginx.log \
-            --data-version 0
+            --where webserver01 --what nginx /path/to/nginx.log
 
 Push a log file with a specific work-id:
 
         datalake push --start 2015-03-20T00:00:05:32.345Z \
             --end 2015-03-20T00:00:34.114Z \
-            --what blappo-etl --where backend01 --data-version 0 \
+            --what blappo-etl --where backend01 \
             --work-id blappo-14321359
 
 The work-id is convenient for tracking processing jobs or other entities that

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -46,8 +46,7 @@ files that have a start and end time associated with them.
 Push the file to the datalake:
 
         datalake push --start=2015-10-01 --end=2015-10-02 \
-                 --where server123 --what ${USER} --data-version 0 \
-                 ${USER}.log
+                 --where server123 --what ${USER} ${USER}.log
 
 
 Now you can query for the file:

--- a/datalake/archive.py
+++ b/datalake/archive.py
@@ -46,11 +46,11 @@ class Archive(object):
     def _parsed_storage_url(self):
         return urlparse.urlparse(self.storage_url)
 
-    def prepare_metadata_and_push(self, path, **metadata_fields):
+    def prepare_metadata_and_push(self, filename, **metadata_fields):
         '''push a file to the archive with the specified metadata
 
         Args:
-            path: path of the file to push
+            filename: path of the file to push
 
             metadata_fields: metadata fields for file. Missing fields will be
             added if they can be determined. Othwerise, InvalidDatalakeMetadata
@@ -58,7 +58,7 @@ class Archive(object):
 
         returns the url to which the file was pushed.
         '''
-        f = File(path, **metadata_fields)
+        f = File.from_filename(filename, **metadata_fields)
         return self.push(f)
 
     def push(self, f):

--- a/datalake/dlfile.py
+++ b/datalake/dlfile.py
@@ -22,23 +22,36 @@ from datalake_common import Metadata
 class File(object):
     '''A File to be manipulated by the Archive'''
 
-    def __init__(self, path, **metadata_fields):
+    def __init__(self, fd, **metadata_fields):
         '''Create a File
 
         Args:
 
-            path: path to the file
+            fd: file-like object from which the file data can be read.
 
             metadata_fields: known metadata fields that go with this
             file. Missing fields will be added if they can be
             determined. Othwerise, InvalidDatalakeMetadata will be raised.
 
         '''
-        self._fd = open(path, 'r')
-        self._path = os.path.abspath(path)
+        self._fd = fd
         self._initialize_methods_from_fd()
         self._infer_metadata_fields(metadata_fields)
         self.metadata = Metadata(metadata_fields)
+
+    @classmethod
+    def from_filename(cls, filename, **metadata_fields):
+        '''Create a File from a filename
+
+        This is a convenience method that opens the file and adds the filename
+        to the metadata_fields for convenience.
+
+        '''
+        filename = os.path.abspath(filename)
+        if 'path' not in metadata_fields:
+            metadata_fields['path'] = filename
+        fd = open(filename)
+        return cls(fd, **metadata_fields)
 
     def _initialize_methods_from_fd(self):
         for m in ['read', 'readlines', 'seek', 'tell', 'close']:
@@ -66,7 +79,7 @@ class File(object):
             if value is None or '~' not in value:
                 continue
             t = Translator(value)
-            metadata_fields[f] = t.translate(self._path)
+            metadata_fields[f] = t.translate(metadata_fields['path'])
 
     _HASH_BUF_SIZE = 65536
 
@@ -74,10 +87,12 @@ class File(object):
         '''16-byte blake2b hash over the content of this file'''
         # this takes just under 2s on my laptop for a 1GB file.
         b2 = blake2b(digest_size=16)
-        with open(self._path, 'rb') as f:
-            while True:
-                data = f.read(self._HASH_BUF_SIZE)
-                if not data:
-                    break
-                b2.update(data)
+        current = self.tell()
+        self.seek(current)
+        while True:
+            data = self.read(self._HASH_BUF_SIZE)
+            if not data:
+                break
+            b2.update(data)
+        self.seek(current)
         return b2.hexdigest()

--- a/datalake/scripts/cli.py
+++ b/datalake/scripts/cli.py
@@ -188,7 +188,7 @@ def enqueue(file, **kwargs):
 def _enqueue(file, **kwargs):
     kwargs = _evaluate_arguments(file, **kwargs)
     e = Enqueuer()
-    f = e.enqueue(file, **kwargs)
+    e.enqueue(file, **kwargs)
     click.echo('Enqueued {}'.format(file))
 
 

--- a/datalake/scripts/cli.py
+++ b/datalake/scripts/cli.py
@@ -186,12 +186,10 @@ def enqueue(file, **kwargs):
 
 @clean_up_datalake_errors
 def _enqueue(file, **kwargs):
-    _prepare_archive_or_fail()
     kwargs = _evaluate_arguments(file, **kwargs)
     e = Enqueuer()
     f = e.enqueue(file, **kwargs)
-    url = archive.url_from_file(f)
-    click.echo('Enqueued {} to {}'.format(file, url))
+    click.echo('Enqueued {}'.format(file))
 
 
 @cli.command()

--- a/datalake/scripts/cli.py
+++ b/datalake/scripts/cli.py
@@ -130,7 +130,6 @@ def _prepare_archive_or_fail():
 @click.option('--end')
 @click.option('--where')
 @click.option('--what')
-@click.option('--data-version')
 @click.option('--work-id')
 @click.argument('file')
 def push(**kwargs):
@@ -179,7 +178,6 @@ def _translate(**kwargs):
 @click.option('--end')
 @click.option('--where')
 @click.option('--what')
-@click.option('--data-version')
 @click.option('--work-id')
 @click.argument('file')
 def enqueue(file, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='datalake',
           'simplejson>=3.7',
           'pyblake2>=0.9.3',
           'click>=4.1',
-          'datalake-common>=0.12',
+          'datalake-common>=0.13',
           'python-dotenv>=0.1.3',
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='datalake',
           'simplejson>=3.7',
           'pyblake2>=0.9.3',
           'click>=4.1',
-          'datalake-common>=0.13',
+          'datalake-common>=0.14',
           'python-dotenv>=0.1.3',
       ],
       extras_require={

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,13 +52,21 @@ def archive(s3_bucket):
 
 
 @pytest.fixture
-def s3_key(s3_conn):
+def s3_key(s3_conn, s3_bucket):
 
-    def get_s3_key(url):
-        url = urlparse(url)
-        assert url.scheme == 's3'
-        bucket = s3_conn.get_bucket(url.netloc)
-        return bucket.get_key(url.path)
+    def get_s3_key(url=None):
+        if url is None:
+            # if no url is specified, assume there is just one key in the
+            # bucket. This is the common case for tests that only push one
+            # item.
+            keys = [k for k in s3_bucket.list()]
+            assert len(keys) == 1
+            return keys[0]
+        else:
+            url = urlparse(url)
+            assert url.scheme == 's3'
+            bucket = s3_conn.get_bucket(url.netloc)
+            return bucket.get_key(url.path)
 
     return get_s3_key
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -25,19 +25,17 @@ def test_cli_with_version_succeeds(cli_tester):
 
 
 def test_push_with_metadata(cli_tester, tmpfile):
-    cmd = ('push --start=2015-05-15 --end=2015-05-16 --where box --what log '
-           '--data-version 0 ')
+    cmd = 'push --start=2015-05-15 --end=2015-05-16 --where box --what log '
     cli_tester(cmd + tmpfile(''))
 
 
 def test_push_without_end(cli_tester, tmpfile):
-    cmd = ('push --data-version 0 --start=2015-05-15 --where=cron '
-           '--what=report ' + tmpfile(''))
+    cmd = ('push --start=2015-05-15 --where=cron --what=report ' + tmpfile(''))
     cli_tester(cmd)
 
 
 def test_push_with_aws_vars(cli_tester, tmpfile):
-    cmd = ('-k abcd -s 1234 -r us-gov-west-1 push --data-version 0 '
+    cmd = ('-k abcd -s 1234 -r us-gov-west-1 push '
            '--start=2015-09-14 --where=cron --what=report ' + tmpfile(''))
     cli_tester(cmd)
 
@@ -47,7 +45,7 @@ def test_push_with_config_file(cli_tester, tmpfile):
                    "aws_secret": "1234",
                    "aws_region": "us-gov-west-1"}'''
     cfg = tmpfile(cfg_json)
-    cmd = ('-c ' + cfg + ' push --data-version 0 --start=2015-09-14 '
+    cmd = ('-c ' + cfg + ' push --start=2015-09-14 '
            '--where=cron --what=report /dev/null')
     cli_tester(cmd)
 
@@ -67,14 +65,13 @@ def test_translate_with_good_args_succceeds(cli_tester):
 def test_crtime_and_now(cli_tester, tmpfile):
     f = tmpfile('contents')
     cmd = 'push --start=crtime --where=server123 '
-    cmd += '--what=test --data-version 0 --end=now ' + f
+    cmd += '--what=test --end=now ' + f
     cli_tester(cmd)
 
 
 def test_push_with_default_where(monkeypatch, cli_tester, tmpfile):
     monkeypatch.setenv('DATALAKE_DEFAULT_WHERE', 'hostname')
-    cmd = ('push --start=2015-05-15 --end=2015-05-16 --what log '
-           '--data-version 0 ')
+    cmd = 'push --start=2015-05-15 --end=2015-05-16 --what log '
     cli_tester(cmd + tmpfile(''))
 
 
@@ -83,5 +80,5 @@ def test_push_with_translation_expression(cli_tester, tmpdir):
     f.write('blaaaa')
     cmd = 'push --work-id=.*job-(?P<job_id>[0-9]+).log$~job{job_id} '
     cmd += '--what=job --start=now --end=now --where=hostname '
-    cmd += '--data-version 0 ' + str(f)
+    cmd += str(f)
     cli_tester(cmd)

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -26,7 +26,7 @@ def random_file(tmpdir, metadata=None):
     f.write(content)
     if metadata is None:
         metadata = random_metadata()
-    return File(f.strpath, **metadata)
+    return File.from_filename(f.strpath, **metadata)
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def test_file_hash_different(random_files):
 
 def test_non_existent_file():
     with pytest.raises(IOError):
-        File('surelythisfiledoesnotexist.txt')
+        File.from_filename('surelythisfiledoesnotexist.txt')
 
 
 def test_not_enough_metadata(tmpdir):

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -107,7 +107,7 @@ def test_upload_existing_cli(cli_tester, random_file, random_metadata,
     if random_metadata.get('work_id'):
         cmd += '--work-id {work_id} '
     cmd = cmd.format(**random_metadata)
-    output = cli_tester(cmd + random_file)
+    cli_tester(cmd + random_file)
     cmd = 'uploader --timeout=0.1'
     cli_tester(cmd)
 

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -103,7 +103,7 @@ def test_upload_incoming(enqueuer, uploader, random_file, random_metadata,
 def test_upload_existing_cli(cli_tester, random_file, random_metadata,
                              uploaded_content_validator, queue_dir):
     cmd = 'enqueue --start={start} --end={end} --where {where} '
-    cmd += '--what {what} --data-version {data_version} '
+    cmd += '--what {what} '
     if random_metadata.get('work_id'):
         cmd += '--work-id {work_id} '
     cmd = cmd.format(**random_metadata)
@@ -122,7 +122,7 @@ def test_upload_existing_cli(cli_tester, random_file, random_metadata,
 def test_enqueue_with_crtime_and_now(cli_tester, random_file, random_metadata,
                                      uploaded_content_validator, queue_dir):
     cmd = 'enqueue --start=crtime --end=now --where server37 '
-    cmd += '--what randomefile --data-version 0 '
+    cmd += '--what randomefile '
     cli_tester(cmd + random_file)
 
 

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -45,8 +45,9 @@ def uploader(archive, queue_dir):
 @pytest.fixture
 def uploaded_content_validator(s3_key):
 
-    def validator(url, expected_content, expected_metadata=None):
-        from_s3 = s3_key(url)
+    def validator(expected_content, expected_metadata=None):
+
+        from_s3 = s3_key()
         assert from_s3 is not None
         assert from_s3.get_contents_as_string() == expected_content
         if expected_metadata is not None:
@@ -61,8 +62,7 @@ def uploaded_file_validator(archive, uploaded_content_validator):
 
     def validator(f):
         expected_content = f.read()
-        url = archive.url_from_file(f)
-        uploaded_content_validator(url, expected_content, f.metadata)
+        uploaded_content_validator(expected_content, f.metadata)
 
     return validator
 
@@ -108,13 +108,11 @@ def test_upload_existing_cli(cli_tester, random_file, random_metadata,
         cmd += '--work-id {work_id} '
     cmd = cmd.format(**random_metadata)
     output = cli_tester(cmd + random_file)
-    url = output.rstrip('\n').split()[-1]
-
     cmd = 'uploader --timeout=0.1'
     cli_tester(cmd)
 
     expected_content = open(random_file).read()
-    uploaded_content_validator(url, expected_content)
+    uploaded_content_validator(expected_content)
 
 
 @pytest.mark.skipif(not has_queue or not crtime_setuid,


### PR DESCRIPTION
We've made a couple of minor changes to the metadata. Specifically, we no longer require data version, and we require the path to the original file.

Also, do not create an archive as part of the enqueue CLI. This will allow users to enqueue files without actually contacting s3, which is kinda part of the point.