### PR TITLE
use tarfiles instead of xattr to bind datalake files and metadata

### DIFF
--- a/datalake/__init__.py
+++ b/datalake/__init__.py
@@ -16,9 +16,11 @@ import pyver
 
 __version__, __version_info__ = pyver.get_version(pkg='datalake')
 __all__ = ['File', 'Archive', 'Uploader', 'Enqueuer', 'get_crtime',
-           'CreationTimeError', 'Translator', 'TranslatorError']
+           'CreationTimeError', 'Translator', 'TranslatorError',
+           'InvalidDatalakeBundle']
 
-from dlfile import File
+
+from dlfile import File, InvalidDatalakeBundle
 from archive import Archive
 from queue import Uploader, Enqueuer
 from translator import Translator, TranslatorError

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(name='datalake',
           # to a separate uploader process.
           'queuable': [
               'pyinotify>=0.9.4',
-              'xattr>=0.7.8',
           ],
           'sentry': [
               'raven>=5.0.0',


### PR DESCRIPTION
Why? symlinks aren't going to work. Consider the case in which
logrotate is enqueuing logs to the queue directory. If the
uploader crashes or otherwise fails to process one of the
enqueued files, the next logrotate run will overwrite the failed
file. Not only will this prevent recovery, it will cause
confusion. The disk overhead of this scheme is a noted cost that
we accept.