### PR TITLE
fix rstrip bug

### DIFF
--- a/datalake/archive.py
+++ b/datalake/archive.py
@@ -13,6 +13,7 @@
 # the License.
 
 import os
+import re
 from os import environ
 import urlparse
 from memoized_property import memoized_property
@@ -203,7 +204,8 @@ class Archive(object):
         return File(fd, **m)
 
     def _get_metadata_from_http_url(self, url):
-        url = url.rstrip('/data') + '/metadata'
+        p = re.compile('/data$')
+        url = p.sub('/metadata', url)
         response = requests.get(url, stream=True)
         self._check_http_response(response)
         return response.json()

--- a/test/test_fetch.py
+++ b/test/test_fetch.py
@@ -112,3 +112,15 @@ def test_invalid_server(archive, random_metadata):
     url = 'http://not-my-datalake.example.com/v0/archive/files/1234/data'
     with pytest.raises(InvalidDatalakePath):
         archive.fetch(url)
+
+@responses.activate
+def test_metadata_from_http_url(archive, random_metadata):
+    url = 'http://datalake.example.com/v0/archive/files/1234data'
+    responses.add(responses.GET, url + '/data', body='foobody',
+                  content_type='text/plain', status=200)
+    responses.add(responses.GET, url + '/metadata', json=random_metadata,
+                  content_type='application/json', status=200)
+    f = archive.fetch(url + '/data')
+    assert f.read() == 'foobody'
+    assert f.metadata == random_metadata
+

--- a/test/test_fetch.py
+++ b/test/test_fetch.py
@@ -113,6 +113,7 @@ def test_invalid_server(archive, random_metadata):
     with pytest.raises(InvalidDatalakePath):
         archive.fetch(url)
 
+
 @responses.activate
 def test_metadata_from_http_url(archive, random_metadata):
     url = 'http://datalake.example.com/v0/archive/files/1234data'
@@ -123,4 +124,3 @@ def test_metadata_from_http_url(archive, random_metadata):
     f = archive.fetch(url + '/data')
     assert f.read() == 'foobody'
     assert f.metadata == random_metadata
-


### PR DESCRIPTION
Since `rstrip` takes in a parameter that is a set of characters to be stripped, if the next character matched any of the set `('/', 'd', 'a', 't')`, they were stripped along with `/data`.