### PR TITLE
fix README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Developer Setup
 
         apt-get install libffi-dev # to enable queuable feature
         mkvirtualenv datalake # Or however you like to manage virtualenvs
-        pip install -e .[queuable, test]
+        pip install -e .[queuable,test]
         flake8 .
         py.test
 


### PR DESCRIPTION
`pip install -e .[queuable, test]` throws the following exception:
```
...
  File "/home/daniel/datalake/venv/local/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2889, in scan_list
    raise RequirementParseError(msg, line, "at", line[p:])
RequirementParseError: Expected version spec in test] at 
```
`pip install -e .[queuable,test]` works great.