### PR TITLE
give uploader a multi-thread option

### DIFF
--- a/datalake/scripts/cli.py
+++ b/datalake/scripts/cli.py
@@ -194,6 +194,7 @@ def _enqueue(file, **kwargs):
 
 @cli.command()
 @click.option('--timeout', type=float)
+@click.option('--workers', type=int, default=1)
 def uploader(**kwargs):
     _uploader(**kwargs)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,9 +21,13 @@ import os
 from click.testing import CliRunner
 import stat
 import responses
+import logging
 
 from datalake.scripts.cli import cli
 from datalake import Archive
+
+
+logging.basicConfig(level=logging.INFO)
 
 
 @pytest.fixture


### PR DESCRIPTION
Allow multiple upload workers. Note that if/when a thread crashes
it kills the whole uploader process via
`thread.interrupt_main`. The exception is logged for debugging
purposes. But for the sake of simplicity, the exception is not
re-raised in the main thread; instead a `KeyboardInterrupt` is
raised.