### PR TITLE
make test fails if any test fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,21 @@ docker: version
 devshell: docker
 	docker run --rm -it -v $$PWD:/opt --entrypoint /bin/bash $(IMAGE)
 
+test-client: docker
+	docker run --rm -it --entrypoint py.test $(IMAGE) client
+
+test-ingester: docker
+	docker run --rm -it --entrypoint py.test $(IMAGE) ingester
+
+test-api: docker
+	docker run --rm -it --entrypoint py.test $(IMAGE) api
+
 .PHONY: test  # Run the tests
-test: docker
+test:
 	echo VERSION=$(VERSION)
-	for p in client ingester api; do \
-		docker run --rm -it --entrypoint py.test $(IMAGE) $$p; \
-	done
+	$(MAKE) test-client
+	$(MAKE) test-ingester
+	$(MAKE) test-api
 
 .PHONY: push
 push:

--- a/ingester/tests/data/s3-notification-multipart-event.json
+++ b/ingester/tests/data/s3-notification-multipart-event.json
@@ -32,7 +32,7 @@
       "url": "s3://datalake-test/2-california/syslog/1612876178000/9fd061c46d004031b2ceafbb729a0ea3-syslog-284.txt",
       "size": 0,
       "create_time": 236574060000,
-      "time_index_key": "16552:syslog",
+      "time_index_key": "18667:syslog",
       "work_id_index_key": "null9fd061c46d004031b2ceafbb729a0ea3:syslog",
       "range_key": "california:9fd061c46d004031b2ceafbb729a0ea3",
       "metadata": {


### PR DESCRIPTION
Noticed when examining the Travis CI [docker job](https://travis-ci.org/github/planetlabs/datalake/jobs/759536948) for the [latest commit](https://github.com/planetlabs/datalake/commit/17a3a1fbe2c5f2beb09aa275032a9de13e227b52) that a test was failing in the ingester folder, but the CI job still passes.

**Changes:**
- modify makefile to fail upon any of the ingester, api, and client make test rules failing
- fix the failing ingester test added in the previous commit