### PR TITLE
remove pypi and docker publishing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,15 +1,8 @@
-name: Run tests and publish to PyPI
-on:
-  push:
-    tags:
-      - '*'
-env:
-  PYPI_USER: __token__
-  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+name: Run tests
+on: [push, pull_request]
+
 jobs:
-  test-multiple-python-versions-and-extras:
+  test-client:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,40 +30,4 @@ jobs:
           fetch-depth: 0
       - name: Test
         run: |
-          echo ${{ env.DOCKER_PASSWORD }} | docker login --username $DOCKER_USERNAME --password-stdin
           make test
-  publish-to-pypi:
-    # only publish if all tests pass
-    needs: [test-multiple-python-versions-and-extras, test-docker]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.5
-      - name: Check out repository code
-        uses: actions/checkout@v2
-      - name: Create distribution
-        working-directory: ./client
-        run: |
-          pip install twine
-          pip install build
-          python -m build --sdist
-          python -m build --wheel
-      - name: Publish to PyPI
-        working-directory: ./client
-        run: |
-          twine upload -r pypi -u ${{ env.PYPI_USER }} \
-          -p ${{ env.PYPI_TOKEN }} dist/*
-  save-docker:
-    needs: [test-multiple-python-versions-and-extras, test-docker]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Upload
-        run: |
-          echo ${{ env.DOCKER_PASSWORD }} | docker login --username $DOCKER_USERNAME --password-stdin
-          make push

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+stages:
+  - prep
+  - trigger
+
+prep:
+  stage: prep
+  image: python:3.9-alpine
+  script:
+    - pip install jinja-cli==1.2.1
+    - jinja
+      -D PLANET_CI_IMAGE $PLANET_CI_IMAGE
+      -D PLANET_RUNNER_TAG $PLANET_RUNNER_TAG
+      ./.gitlab-ci.yml.j2 > generated-gitlab-ci.yml
+  artifacts:
+    paths:
+      - generated-gitlab-ci.yml
+
+trigger:
+  stage: trigger
+  trigger:
+    include:
+      - artifact: generated-gitlab-ci.yml
+        job: prep
+    strategy: depend

--- a/.gitlab-ci.yml.j2
+++ b/.gitlab-ci.yml.j2
@@ -1,0 +1,36 @@
+services:
+  - docker:18-dind
+
+stages:
+  - build
+  - publish
+
+build-docker:
+  stage: build
+  image: {{PLANET_CI_IMAGE}}
+  variables:
+    REPO: $CI_REGISTRY
+    REPO_PATH: $CI_PROJECT_PATH
+  script:
+    - rm -f version.txt
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY/$CI_PROJECT_PATH
+    - make docker test push
+  tags:
+    - {{PLANET_RUNNER_TAG}}
+  artifacts:
+    paths:
+      - version.txt
+
+publish-pypi:
+  stage: publish
+  image: {{PLANET_CI_IMAGE}}
+  script:
+    - cd client
+    - rm -rf dist
+    - python3 setup.py sdist bdist_wheel
+    - twine upload -r pypi --skip-existing dist/*
+  tags:
+    - {{PLANET_RUNNER_TAG}}
+  only:
+    - tags
+    - /^v[0-9]+(\.[0-9]+)*$/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION=$(shell git describe --tags --dirty)
-REPO=planetlabs
-IMAGE="$(REPO)/datalake:$(VERSION)"
+REPO ?= planetlabs
+REPO_PATH ?= datalake
+IMAGE="$(REPO)/$(REPO_PATH):$(VERSION)"
 
 .PHONY: docker # build the docker container
 docker: version
@@ -28,15 +29,6 @@ test:
 
 .PHONY: push
 push:
-ifeq ($(DOCKER_USERNAME),)
-	echo "You must set DOCKER_USERNAME"
-	exit 1
-endif
-ifeq ($(DOCKER_PASSWORD),)
-	echo "You must set DOCKER_PASSWORD"
-	exit 1
-endif
-	echo "$(DOCKER_PASSWORD)" | docker login -u "$(DOCKER_USERNAME)" --password-stdin && \
 	docker push $(IMAGE)
 
 clean:


### PR DESCRIPTION
We no longer publish to the public dockerhub, and we use an
internal CI server to push releases to pypi. This reduces
public/open visibility in this process. But it spares us from
having to distribute tokens to third parties.