### PR TITLE
drop boto2 from client

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,10 +3,9 @@ on: [push, pull_request]
 
 jobs:
   test-client:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        # 4 jobs total with all permutations
         python: [3.6, 3.8, 3.9]
         extras: ["test", "test,queable,sentry"]
     steps:
@@ -30,4 +29,4 @@ jobs:
           fetch-depth: 0
       - name: Test
         run: |
-          make test
+          make test-ingester test-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ENV	LC_ALL C.UTF-8
 # TODO: keep requirements in one place
 RUN pip install \
     blinker>=1.4 \
-    boto>=2.38.0 \
     boto3>=1.1.3 \
     click>=5.1 \
     Flask>=0.10.1 \
@@ -28,7 +27,9 @@ RUN pip install \
     'pytest<8' \
     'responses<0.22.0' \
     pyinotify>=0.9.4, \
-    raven>=5.0.0
+    raven>=5.0.0 \
+    'tox>4,<5' \
+    'datalake<2'
 
 RUN mkdir -p /opt/
 COPY . /opt/
@@ -37,7 +38,7 @@ COPY . /opt/
 # the container and used for development. That is, the python paths and paths
 # to console scripts Just Work (TM)
 ENV PYTHONPATH=/opt/client:/opt/ingester:/opt/api
-RUN for d in client ingester api; do \
+RUN for d in ingester api; do \
     cd /opt/$d && \
     python setup.py develop -s /usr/local/bin \
         --egg-path ../../../../../opt/$d/ \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ devshell: docker
 	docker run --rm -it -v $$PWD:/opt --entrypoint /bin/bash $(IMAGE)
 
 test-client: docker
-	docker run --rm --entrypoint py.test $(IMAGE) client
+	docker run --rm --entrypoint tox $(IMAGE) -c /opt/client/tox.ini
 
 test-ingester: docker
 	docker run --rm --entrypoint py.test $(IMAGE) ingester

--- a/client/datalake/logging_helpers.py
+++ b/client/datalake/logging_helpers.py
@@ -5,7 +5,7 @@ command line client may choose to configure logging in some cases. Users with
 sentry accounts may wish to configure it by installing the sentry extras.
 '''
 import os
-import logging
+import logging.config
 from .common.errors import InsufficientConfiguration
 
 

--- a/client/setup.py
+++ b/client/setup.py
@@ -21,7 +21,7 @@ setup(name='datalake',
       author_email='brian@planet.com',
       packages=find_packages(exclude=['test']),
       install_requires=[
-          'boto>=2.38.0',
+          'boto3>=1.9.68',
           'memoized_property>=1.0.1',
           'pyblake2>=0.9.3; python_version<"3.6"',
           'click>=4.1',
@@ -34,7 +34,7 @@ setup(name='datalake',
       extras_require={
           'test': [
               'pytest<8.0.0',
-              'moto<3.0.0',
+              'moto[s3]>4,<5',
               'twine<4.0.0',
               'pip>=20.0.0,<22.0.0',
               'wheel<0.38.0',

--- a/client/test/test_cli.py
+++ b/client/test/test_cli.py
@@ -14,8 +14,8 @@
 
 import pytest
 from test_crtime import crtime_setuid
-from click.testing import CliRunner
 import random
+
 
 def test_cli_without_command_fails(cli_tester):
     cli_tester('', expected_exit=2)
@@ -62,17 +62,18 @@ def test_translate_with_good_args_succceeds(cli_tester):
     cli_tester(cmd)
 
 
-@pytest.mark.parametrize("content", [['text'], ['multiple', 'things']])  
-def test_cat(cli_tester, datalake_url_maker, random_metadata, content):
+@pytest.mark.parametrize("content", [['text'], ['multiple', 'things']])
+def test_cat(cli_tester, datalake_url_maker, random_metadata, content,
+             s3_connection):
     metadata1 = random_metadata
     metadata2 = random_metadata.copy()
     metadata2['id'] = ('%0' + str(40) + 'x') % random.randrange(16**40)
     url = ""+datalake_url_maker(metadata=metadata1, content=content[0])
     if content[0] == 'multiple':
-        for i in range (1, len(content)):
-            url = url + " " + datalake_url_maker(metadata=metadata2, content=content[i])
-    cmd = ("cat "+url)
-    print(cmd)
+        for i in range(1, len(content)):
+            url = (url + " " +
+                   datalake_url_maker(metadata=metadata2, content=content[i]))
+    cmd = "cat " + url
     output = cli_tester(cmd)
     output = output.split('\n')
     for i in range(len(content)):

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py3
+
+[testenv]
+deps = -e .[test,queuable,sentry]
+commands = py.test {posargs}
+usedevelop = True

--- a/ingester/setup.py
+++ b/ingester/setup.py
@@ -51,7 +51,6 @@ setup(name='datalake_ingester',
       author_email='brian@planet.com',
       packages=['datalake_ingester'],
       install_requires=[
-          'boto>=2.38.0',
           'memoized_property>=1.0.2',
           'simplejson>=3.3.1',
           'sentry-sdk>=0.19.5',


### PR DESCRIPTION
Note that this work relies heavily on work by @lod in https://github.com/planetlabs/datalake/pull/78/

Note that the ingester and api both need this treatment too. And both the ingester and the api rely on the datalake client for shared code (e.g., Record, Metadata, various test fixtures). But migrating just the client was a heavy enough lift. To preserve the ingester and api funtionality, I made the docker container install datalake<1. We will migrate these back to the main line code in subsequent PRs.