### PR TITLE
Added default client version for docker builds

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -59,6 +59,8 @@ datalake = "datalake.scripts.cli:cli"
 [tool.setuptools.packages.find]
 exclude = ["test"]
 
+[tool.versioningit]
+default-version = "0.0.0-dev"
 
 [tool.versioningit.format]
 distance = "{base_version}+{distance}.{vcs}{rev}"

--- a/client/test/test_queue.py
+++ b/client/test/test_queue.py
@@ -264,4 +264,4 @@ def test_threaded_uploader_exits(enqueuer, faulty_uploader, random_file,
                                  random_metadata, uploaded_file_validator):
     enqueuer.enqueue(random_file, **random_metadata)
     with pytest.raises(KeyboardInterrupt):
-        faulty_uploader.listen(timeout=0.1, workers=2)
+        faulty_uploader.listen(timeout=1.0, workers=2)


### PR DESCRIPTION
We don't have git available inside the container for docker test/builds for the client, so we can fall back to a default version.