### PR TITLE
None val end bugfix.

### DIFF
--- a/ingester/datalake_ingester/cli.py
+++ b/ingester/datalake_ingester/cli.py
@@ -24,7 +24,6 @@ DEFAULT_CONFIG = '/etc/datalake-ingester.env'
 @click.pass_context
 def cli(ctx, **kwargs):
     conf = kwargs.pop('config')
-    # setup logging func
     log_debugger(None, "datalake_ingester:cli.py before load_config", loc='datalake_ingester:cli.py:cli')
     load_config(conf, DEFAULT_CONFIG, **kwargs)
     log_debugger(None, "datalake_ingester:cli.py AFTER load_config", loc='datalake_ingester:cli.py:cli')

--- a/ingester/datalake_ingester/cli.py
+++ b/ingester/datalake_ingester/cli.py
@@ -1,6 +1,7 @@
 import click
 from datalake.common.conf import load_config
 from .ingester import Ingester
+from .log import log_debugger
 
 
 DEFAULT_CONFIG = '/etc/datalake-ingester.env'
@@ -23,7 +24,10 @@ DEFAULT_CONFIG = '/etc/datalake-ingester.env'
 @click.pass_context
 def cli(ctx, **kwargs):
     conf = kwargs.pop('config')
+    # setup logging func
+    log_debugger(None, "datalake_ingester:cli.py before load_config", loc='datalake_ingester:cli.py:cli')
     load_config(conf, DEFAULT_CONFIG, **kwargs)
+    log_debugger(None, "datalake_ingester:cli.py AFTER load_config", loc='datalake_ingester:cli.py:cli')
 
 
 def _subcommand_or_fail(ctx):
@@ -33,5 +37,8 @@ def _subcommand_or_fail(ctx):
 
 @cli.command()
 def listen():
+    log_debugger(None, "datalake_ingester:listen.py before instantiating Ingester", loc='datalake_ingester:cli.py:listen')
     i = Ingester.from_config()
     i.listen()
+    log_debugger(None, f"datalake_ingester:listen.py AFTER instantiating Ingester: {i}", loc='datalake_ingester:cli.py:listen')
+

--- a/ingester/datalake_ingester/ingester.py
+++ b/ingester/datalake_ingester/ingester.py
@@ -23,7 +23,7 @@ SAFE_EXCEPTIONS = [
     InvalidDatalakeMetadata,
     UnsupportedS3Event
 ]
-
+from .log import log_debugger
 
 class IngesterReport(dict):
 
@@ -83,6 +83,7 @@ class Ingester(object):
     def ingest(self, url):
         '''ingest the metadata associated with the given url'''
         records = DatalakeRecord.list_from_url(url)
+        log_debugger(logger, "Ingester:ingest", loc=self.__class__.__name__)
         for r in records:
             self.storage.store(r)
 
@@ -117,6 +118,7 @@ class Ingester(object):
     def _add_records(self, datalake_records, ir):
         for r in datalake_records:
             ir.add_record(r)
+            log_debugger(logger, "Ingester:_add_records", loc=self.__class__.__name__, )
             self.storage.store(r)
 
     def _update_records(self, datalake_records, ir):
@@ -135,4 +137,5 @@ class Ingester(object):
             raise InsufficientConfiguration('No queue configured.')
 
         self.queue.set_handler(self.handler)
+        log_debugger(logger, "Ingester:listen", loc=self.__class__.__name__)
         self.queue.drain(timeout=timeout)

--- a/ingester/datalake_ingester/log.py
+++ b/ingester/datalake_ingester/log.py
@@ -22,6 +22,8 @@ def log_debugger(logger=None, message='', loc='', conf=None):
     if logger:
         # Log at different levels
         logger.info(f"======= Inside {loc} log_debugger logger.info: {message} =======\n")
+        logger.warning(f"======= Inside {loc} log_debugger logger.warning: {message} =======\n")
+
 
 conf = {
     'version': 1,
@@ -46,32 +48,3 @@ conf = {
 }
 
 log_debugger(conf=conf)
-
-"""
-def log_debugger(logger_type, message, loc=None):
-    print(f'=======Inside {loc} log_debugger print: at {message}=======')
-    if logger:
-        logger_type.info(f"=======Inside {loc} log_debugger logger.info=======")
-        logger_type.warning(f"=======Inside {loc} log_debugger logger.warning=======")
-        logger_type.error(f"=======Inside {loc} log_debugger logger.error=======")
-        logger_type.debug(f"=======Inside {loc} log_debugger logger.error=======")
-    else:
-        #setup logger
-        logger = logging.getLogger('test_logger')
-        logger.setLevel(logging.DEBUG)
-        ch = logging.StreamHandler()
-
-        ch.setLevel(logging.DEBUG)
-        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-        ch.setFormatter(formatter)
-        logger.addHandler(ch)
-        logger.info(f"=======Inside {loc} log_debugger logger.info=======")
-        logger.warning(f"=======Inside {loc} log_debugger logger.warning=======")
-        logger.error(f"=======Inside {loc} log_debugger logger.error=======")
-        logger.debug(f"=======Inside {loc} log_debugger logger.error=======")
-
-"""
-
-# sentry_sdk.init()
-# logging.config.dictConfig(conf)

--- a/ingester/datalake_ingester/log.py
+++ b/ingester/datalake_ingester/log.py
@@ -2,6 +2,27 @@ import logging
 import sentry_sdk
 
 
+def log_debugger(logger=None, message='', loc='', conf=None):
+    """
+    Initializes logging configuration and logs messages at different levels.
+
+    Parameters:
+        logger (logging.Logger): The logger instance to use for logging.
+        message (str): The message to log.
+        loc (str, optional): The location information (e.g., file or class). Defaults to ''.
+        conf (dict, optional): The logging configuration dictionary.
+    """
+    sentry_sdk.init()
+    if conf:
+        logging.config.dictConfig(conf)
+    logging.debug("Logging has been initialized with the provided configuration.")
+
+    print(f'\n======= Inside {loc} log_debugger print: at {message} =======')
+
+    if logger:
+        # Log at different levels
+        logger.info(f"======= Inside {loc} log_debugger logger.info: {message} =======\n")
+
 conf = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -13,7 +34,7 @@ conf = {
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-            'level': 'INFO',
+            'level': 'DEBUG',
             'formatter': 'simple',
             'stream': 'ext://sys.stdout'
         },
@@ -24,8 +45,33 @@ conf = {
     }
 }
 
+log_debugger(conf=conf)
 
-sentry_sdk.init()
+"""
+def log_debugger(logger_type, message, loc=None):
+    print(f'=======Inside {loc} log_debugger print: at {message}=======')
+    if logger:
+        logger_type.info(f"=======Inside {loc} log_debugger logger.info=======")
+        logger_type.warning(f"=======Inside {loc} log_debugger logger.warning=======")
+        logger_type.error(f"=======Inside {loc} log_debugger logger.error=======")
+        logger_type.debug(f"=======Inside {loc} log_debugger logger.error=======")
+    else:
+        #setup logger
+        logger = logging.getLogger('test_logger')
+        logger.setLevel(logging.DEBUG)
+        ch = logging.StreamHandler()
 
+        ch.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-logging.config.dictConfig(conf)
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+        logger.info(f"=======Inside {loc} log_debugger logger.info=======")
+        logger.warning(f"=======Inside {loc} log_debugger logger.warning=======")
+        logger.error(f"=======Inside {loc} log_debugger logger.error=======")
+        logger.debug(f"=======Inside {loc} log_debugger logger.error=======")
+
+"""
+
+# sentry_sdk.init()
+# logging.config.dictConfig(conf)

--- a/ingester/datalake_ingester/storage.py
+++ b/ingester/datalake_ingester/storage.py
@@ -89,6 +89,11 @@ class DynamoDBStorage(object):
         else:
             work_id_value = {'S': str(record['metadata']['work_id'])}
 
+        if record['metadata']['end'] is None:
+            end_time_value = {'NULL': True}
+        else:
+            end_time_value = {'N': str(record['metadata']['end'])}
+
         record = {
             'what_where_key': {"S": record['metadata']['what']+':'+record['metadata']['where']},
             'time_index_key': {"S": record['time_index_key']},
@@ -98,9 +103,7 @@ class DynamoDBStorage(object):
                     'start': {
                         'N': str(record['metadata']['start'])
                     },
-                    'end': {
-                        'N': str(record['metadata']['end'])
-                    },
+                    'end': end_time_value,
                     'id': {
                         'S': str(record['metadata']['id'])
                     },


### PR DESCRIPTION
Storage: Fixing bug when a record is pushed with metadata.end = null. It must be properly stored using attribute value syntax.

Logging: The configuration in ingester.datalake_ingester.log.py is not imported. I have imported that into the ingester, storage, cli files to get more explicit logging during operations/testing.