### PR TITLE
Fix: Add missing import for logging.config in ingester

### DIFF
--- a/ingester/datalake_ingester/log.py
+++ b/ingester/datalake_ingester/log.py
@@ -1,4 +1,5 @@
 import logging
+import logging.config
 import sentry_sdk
 
 _log_configured = False


### PR DESCRIPTION
Needed to fix PR 105 and 106 missing dependencies import
Missed due to stale dependencies that only got removed once full gitlab ci/cd was done